### PR TITLE
fonts classes added (#8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6744,7 +6744,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6781,7 +6782,8 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -6790,7 +6792,8 @@
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6893,7 +6896,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6903,6 +6907,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6922,11 +6927,13 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6943,6 +6950,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7015,7 +7023,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7025,6 +7034,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7100,7 +7110,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7130,6 +7141,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7147,6 +7159,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7185,11 +7198,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }
@@ -7835,9 +7850,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -7860,11 +7875,11 @@
       "integrity": "sha1-0jM6NtnncXyK0vfKyv7HwytERmQ="
     },
     "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
       }
     },

--- a/src/index.css
+++ b/src/index.css
@@ -90,6 +90,79 @@
     src: url('Fonts/Montserrat/italic/Montserrat-ThinItalic.ttf') format('truetype')
 }
 
+/* fonts classes */
+.font-mont-bl {
+    font-family: 'MontserratBlack';
+}
+
+.font-mont-b {
+    font-family: 'MontserratBold';
+}
+
+.font-mont-eb {
+    font-family: 'MontserratExtraBold';
+}
+
+.font-mont-el {
+    font-family: 'MontserratExtraLight';
+}
+
+.font-mont-l {
+    font-family: 'MontserratLight';
+}
+
+.font-mont-m {
+    font-family: 'MontserratMedium';
+}
+
+.font-mont-r {
+    font-family: 'MontserratRegular';
+}
+
+.font-mont-sb {
+    font-family: 'MontserratSemiBold';
+}
+
+.font-mont-t {
+    font-family: 'MontserratThin';
+}
+
+.font-mont-bl-i {
+    font-family: 'MontserratBlackItalic';
+}
+
+.font-mont-b-i {
+    font-family: 'MontserratBoldItalic';
+}
+
+.font-mont-eb-i {
+    font-family: 'MontserratExtraBoldItalic';
+}
+
+.font-mont-el-i {
+    font-family: 'MontserratExtraLightItalic';
+}
+
+.font-mont-l-i {
+    font-family: 'MontserratLightItalic';
+}
+
+.font-mont-m-i {
+    font-family: 'MontserratMediumItalic';
+}
+
+.font-mont-r-i {
+    font-family: 'MontserratRegularItalic';
+}
+
+.font-mont-sb-i {
+    font-family: 'MontserratSemiBoldItalic';
+}
+
+.font-mont-t-i {
+    font-family: 'MontserratThinItalic';
+}
+
 /* common css (index.js level)*/
 * {
     font-family: 'MontserratMedium'


### PR DESCRIPTION
* Bump lodash.template from 4.4.0 to 4.5.0 (#3)

Bumps [lodash.template](https://github.com/lodash/lodash) from 4.4.0 to 4.5.0.
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.4.0...4.5.0)

Signed-off-by: dependabot[bot] <support@github.com>

* Bump lodash from 4.17.11 to 4.17.14 (#4)

Bumps [lodash](https://github.com/lodash/lodash) from 4.17.11 to 4.17.14.
- [Release notes](https://github.com/lodash/lodash/releases)
- [Commits](https://github.com/lodash/lodash/compare/4.17.11...4.17.14)

Signed-off-by: dependabot[bot] <support@github.com>

* fonts classes added